### PR TITLE
Allow to swap the ExecutorService for tests

### DIFF
--- a/objectbox-java/src/main/java/io/objectbox/BoxStore.java
+++ b/objectbox-java/src/main/java/io/objectbox/BoxStore.java
@@ -169,7 +169,7 @@ public class BoxStore implements Closeable {
     private final int[] allEntityTypeIds;
     private final Map<Class, Box> boxes = new ConcurrentHashMap<>();
     private final Set<Transaction> transactions = Collections.newSetFromMap(new WeakHashMap<Transaction, Boolean>());
-    private final ExecutorService threadPool = new ObjectBoxThreadPool(this);
+    private final ExecutorService threadPool;
     private final ObjectClassPublisher objectClassPublisher;
     final boolean debugTxRead;
     final boolean debugTxWrite;
@@ -199,6 +199,12 @@ public class BoxStore implements Closeable {
         directory = builder.directory;
         canonicalPath = getCanonicalPath(directory);
         verifyNotAlreadyOpen(canonicalPath);
+
+        if  (builder.executorService == null) {
+            this.threadPool = new ObjectBoxThreadPool(this);
+        } else {
+            this.threadPool = builder.executorService;
+        }
 
         handle = nativeCreate(canonicalPath, builder.maxSizeInKByte, builder.maxReaders, builder.model);
         int debugFlags = builder.debugFlags;

--- a/objectbox-java/src/main/java/io/objectbox/BoxStoreBuilder.java
+++ b/objectbox-java/src/main/java/io/objectbox/BoxStoreBuilder.java
@@ -30,6 +30,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -95,7 +96,10 @@ public class BoxStoreBuilder {
     TxCallback failedReadTxAttemptCallback;
 
     final List<EntityInfo> entityInfoList = new ArrayList<>();
+
     private Factory<InputStream> initialDbFileFactory;
+
+    ExecutorService executorService;
 
     /** Not for application use. */
     public static BoxStoreBuilder createDebugWithoutModel() {
@@ -368,6 +372,20 @@ public class BoxStoreBuilder {
     @Experimental
     public BoxStoreBuilder initialDbFile(Factory<InputStream> initialDbFileFactory) {
         this.initialDbFileFactory = initialDbFileFactory;
+        return this;
+    }
+
+    /**
+     * Configure a different {@linkplain ExecutorService} that ObjectBox should use to perform its asynchronous
+     * computations like observing data changes. If {@code null} is supplied, the default {@linkplain ExecutorService}
+     * is used.
+     * <p>
+     * To facilitate testing asynchronous computations, supply a {@linkplain ExecutorService} that runs all its
+     * computations synchronously on the calling thread.
+     */
+    @Experimental
+    public BoxStoreBuilder executorService(@Nullable ExecutorService executorService) {
+        this.executorService = executorService;
         return this;
     }
 

--- a/tests/objectbox-java-test/src/test/java/io/objectbox/AbstractObjectBoxTest.java
+++ b/tests/objectbox-java-test/src/test/java/io/objectbox/AbstractObjectBoxTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
@@ -85,6 +86,12 @@ public abstract class AbstractObjectBoxTest {
         builder.debugFlags(DebugFlags.LOG_TRANSACTIONS_READ | DebugFlags.LOG_TRANSACTIONS_WRITE);
         builder.entity(new TestEntity_());
         builder.entity(new TestEntityMinimal_());
+        return builder;
+    }
+
+    protected BoxStoreBuilder createBoxStoreBuilderWithTwoEntities(boolean withIndex, ExecutorService executorService) {
+        BoxStoreBuilder builder = createBoxStoreBuilderWithTwoEntities(withIndex);
+        builder.executorService(executorService);
         return builder;
     }
 

--- a/tests/objectbox-java-test/src/test/java/io/objectbox/SynchronousExecutorService.java
+++ b/tests/objectbox-java-test/src/test/java/io/objectbox/SynchronousExecutorService.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 ObjectBox Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.objectbox;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * {@linkplain java.util.concurrent.ExecutorService} that performs all computations sequentially
+ * on the calling thread.
+ */
+public class SynchronousExecutorService extends AbstractExecutorService {
+
+    private boolean isTerminated = false;
+
+    @Override
+    public void shutdown() {
+        this.isTerminated = true;
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return isTerminated;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return isTerminated;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+        return true;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        command.run();
+    }
+}

--- a/tests/objectbox-java-test/src/test/java/io/objectbox/SynchronousObjectClassObserverTest.java
+++ b/tests/objectbox-java-test/src/test/java/io/objectbox/SynchronousObjectClassObserverTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 ObjectBox Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.objectbox;
+
+import io.objectbox.reactive.DataObserver;
+import io.objectbox.reactive.SubscriptionBuilder;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SynchronousObjectClassObserverTest extends AbstractObjectBoxTest {
+
+    final List<Class> classesWithChanges = new ArrayList<>();
+
+    DataObserver objectClassObserver = new DataObserver<Class>() {
+        @Override
+        public void onData(Class objectClass) {
+            classesWithChanges.add(objectClass);
+        }
+    };
+
+    @Override
+    protected BoxStore createBoxStore() {
+        return createBoxStoreBuilderWithTwoEntities(false, new SynchronousExecutorService())
+                .build();
+    }
+
+    @Test
+    public void transactionsAndObservationPerformedSequentially() {
+        final SubscriptionBuilder<Class> subscriptionBuilder = this.store.subscribe();
+        subscriptionBuilder.observer(objectClassObserver);
+
+        assertEquals(2, classesWithChanges.size());
+        assertTrue(classesWithChanges.contains(TestEntity.class));
+        assertTrue(classesWithChanges.contains(TestEntityMinimal.class));
+
+        classesWithChanges.clear();
+        this.store.runInTx(new Runnable() {
+            @Override
+            public void run() {
+                putTestEntities(3);
+            }
+        });
+
+        assertEquals(1, classesWithChanges.size());
+    }
+}


### PR DESCRIPTION
This pull request addresses the problems outlined in #616 using a different approach: swapping the `ExecutorService`. By instructing the `BoxStore` to use an `ExecutorService` that runs all code synchronously, the concurrency issues go away and there's no need anymore to track the pending events.

What do you think? I'm happy to change the API, tests, …