### PR TITLE
Ensure that getAll() always returns a mutable list

### DIFF
--- a/objectbox-java/src/main/java/io/objectbox/Box.java
+++ b/objectbox-java/src/main/java/io/objectbox/Box.java
@@ -306,7 +306,7 @@ public class Box<T> {
         try {
             T first = cursor.first();
             if (first == null) {
-                return Collections.emptyList();
+                return new ArrayList<>();
             } else {
                 ArrayList<T> list = new ArrayList<>();
                 list.add(first);

--- a/tests/objectbox-java-test/src/test/java/io/objectbox/BoxTest.java
+++ b/tests/objectbox-java-test/src/test/java/io/objectbox/BoxTest.java
@@ -103,6 +103,22 @@ public class BoxTest extends AbstractObjectBoxTest {
     }
 
     @Test
+    public void testGetAllResultIsAlwaysMutable() {
+        assertEquals(0, box.count());
+        List<TestEntity> all = box.getAll();
+        all.add(new TestEntity());
+
+        assertEquals(0, box.count());
+        box.put(new TestEntity());
+
+        assertEquals(1, box.count());
+        all = box.getAll();
+
+        assertEquals(1, all.size());
+        all.add(new TestEntity());
+    }
+
+    @Test
     public void testRemoveMany() {
         List<TestEntity> entities = new ArrayList<>();
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
If a box is empty, `getAll()` returns `Collections.emptyList()`. This empty list is immutable which can only be noticed at runtime (`UnsupportedOperationException` is thrown). This is surprising. This pull request changes  `getAll()` in such a way that a mutable list is returned in every case.