### PR TITLE
Kotlin: add flow extension functions for BoxStore and Query

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ buildscript {
         junit_version = '4.13.2'
         mockito_version = '3.8.0'
         kotlin_version = '1.5.0'
+        coroutines_version = '1.5.0'
         dokka_version = '1.4.32'
 
         println "version=$ob_version"

--- a/objectbox-kotlin/build.gradle
+++ b/objectbox-kotlin/build.gradle
@@ -47,6 +47,8 @@ task sourcesJar(type: Jar) {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    // Note: compileOnly as we do not want to require library users to use coroutines.
+    compileOnly "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
     api project(':objectbox-java')
 }

--- a/objectbox-kotlin/src/main/kotlin/io/objectbox/kotlin/Flow.kt
+++ b/objectbox-kotlin/src/main/kotlin/io/objectbox/kotlin/Flow.kt
@@ -1,0 +1,45 @@
+package io.objectbox.kotlin
+
+import io.objectbox.BoxStore
+import io.objectbox.query.Query
+import io.objectbox.reactive.SubscriptionBuilder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+
+/**
+ * Like [SubscriptionBuilder.observer], but emits data changes to the returned flow.
+ * Automatically cancels the subscription when the flow is canceled.
+ *
+ * For example to create a flow to listen to all changes to a box:
+ * ```
+ * store.subscribe(TestEntity::class.java).toFlow()
+ * ```
+ *
+ * Or to get the latest query results on any changes to a box:
+ * ```
+ * box.query().subscribe().toFlow()
+ * ```
+ */
+@ExperimentalCoroutinesApi
+fun <T> SubscriptionBuilder<T>.toFlow(): Flow<T> = callbackFlow {
+    val subscription = this@toFlow.observer {
+            trySendBlocking(it)
+        }
+    awaitClose { subscription.cancel() }
+}
+
+/**
+ * Shortcut for `BoxStore.subscribe(forClass).toFlow()`, see [toFlow].
+ */
+@ExperimentalCoroutinesApi
+fun <T> BoxStore.flow(forClass: Class<T>): Flow<Class<T>> = this.subscribe(forClass).toFlow()
+
+/**
+ * Shortcut for `query.subscribe().toFlow()`, see [toFlow].
+ */
+@ExperimentalCoroutinesApi
+fun <T> Query<T>.flow(): Flow<MutableList<T>> = this@flow.subscribe().toFlow()

--- a/tests/objectbox-java-test/build.gradle
+++ b/tests/objectbox-java-test/build.gradle
@@ -36,6 +36,7 @@ repositories {
 dependencies {
     implementation project(':objectbox-java')
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation project(':objectbox-kotlin')
     implementation "org.greenrobot:essentials:$essentials_version"
 
@@ -48,6 +49,8 @@ dependencies {
     }
 
     testImplementation "junit:junit:$junit_version"
+    // To test Kotlin Flow
+    testImplementation 'app.cash.turbine:turbine:0.5.2'
 }
 
 test {

--- a/tests/objectbox-java-test/src/test/java/io/objectbox/FlowTest.kt
+++ b/tests/objectbox-java-test/src/test/java/io/objectbox/FlowTest.kt
@@ -16,12 +16,11 @@ class FlowTest : AbstractObjectBoxTest() {
     @ExperimentalCoroutinesApi
     @Test
     fun flow_box() {
-        putTestEntities(1)
-
         runBlocking {
             store.flow(TestEntity::class.java).test {
                 assertEquals(TestEntity::class.java, expectItem())
                 putTestEntities(1)
+                // Note: expectItem suspends until event, so no need to wait on OBX publisher thread.
                 assertEquals(TestEntity::class.java, expectItem())
                 cancel() // expect no more events
             }
@@ -32,13 +31,12 @@ class FlowTest : AbstractObjectBoxTest() {
     @ExperimentalCoroutinesApi
     @Test
     fun flow_query() {
-        putTestEntities(1)
-
         runBlocking {
             testEntityBox.query {}.flow().test {
-                assertEquals(1, expectItem().size)
+                assertEquals(0, expectItem().size)
                 putTestEntities(1)
-                assertEquals(2, expectItem().size)
+                // Note: expectItem suspends until event, so no need to wait on OBX publisher thread.
+                assertEquals(1, expectItem().size)
                 cancel() // expect no more events
             }
         }

--- a/tests/objectbox-java-test/src/test/java/io/objectbox/FlowTest.kt
+++ b/tests/objectbox-java-test/src/test/java/io/objectbox/FlowTest.kt
@@ -1,0 +1,46 @@
+package io.objectbox
+
+import app.cash.turbine.test
+import io.objectbox.kotlin.flow
+import io.objectbox.kotlin.query
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.time.ExperimentalTime
+
+
+class FlowTest : AbstractObjectBoxTest() {
+
+    @ExperimentalTime
+    @ExperimentalCoroutinesApi
+    @Test
+    fun flow_box() {
+        putTestEntities(1)
+
+        runBlocking {
+            store.flow(TestEntity::class.java).test {
+                assertEquals(TestEntity::class.java, expectItem())
+                putTestEntities(1)
+                assertEquals(TestEntity::class.java, expectItem())
+                cancel() // expect no more events
+            }
+        }
+    }
+
+    @ExperimentalTime
+    @ExperimentalCoroutinesApi
+    @Test
+    fun flow_query() {
+        putTestEntities(1)
+
+        runBlocking {
+            testEntityBox.query {}.flow().test {
+                assertEquals(1, expectItem().size)
+                putTestEntities(1)
+                assertEquals(2, expectItem().size)
+                cancel() // expect no more events
+            }
+        }
+    }
+}


### PR DESCRIPTION
Proposal to close #807 

This will allow syntax like, for example to create a flow to listen to all changes to a box:
```
val flow = store.subscribe(TestEntity::class.java).toFlow()
```

Or to get the latest query results on any changes to a box:
```
val flow = box.query().subscribe().toFlow()
```

Also adds shortcuts if the subscription does not need to be customized:
```
val flow = store.flow(TestEntity::class.java)
val queryFlow = query.flow()
```