### PR TITLE
Add a test that ensures object box transactions still succeed when us…

### DIFF
--- a/tests/objectbox-java-test/src/test/java/io/objectbox/TransactionTest.java
+++ b/tests/objectbox-java-test/src/test/java/io/objectbox/TransactionTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -441,9 +443,34 @@ public class TransactionTest extends AbstractObjectBoxTest {
     }
 
     @Test
-    public void transactionsOnLargeThreadPool() throws Exception {
+    public void transactionsOnUnboundedThreadPool() throws Exception {
+        //Silence the unnecessary debug output and set the max readers
+        resetBoxStoreWithoutDebugFlags(100);
+
+        runThreadPoolTransactionTest(new ObjectBoxThreadPool(store));
+    }
+
+    @Test
+    public void transactionsOnBoundedThreadPool() throws Exception {
+        //Silence the unnecessary debug output and set the max readers
+        int maxReaders = 100;
+        resetBoxStoreWithoutDebugFlags(maxReaders);
+
+        runThreadPoolTransactionTest(Executors.newFixedThreadPool(maxReaders));
+    }
+
+    private void resetBoxStoreWithoutDebugFlags(int maxReaders) {
+        // Remove existing store
+        tearDown();
+
+        BoxStoreBuilder builder = createBoxStoreBuilder(false);
+        builder.maxReaders = maxReaders;
+        builder.debugFlags = 0;
+        store = builder.build();
+    }
+
+    private void runThreadPoolTransactionTest(ExecutorService pool) throws Exception {
         //Create a bunch of transactions on a thread pool. We can even run them synchronously.
-        ObjectBoxThreadPool pool = new ObjectBoxThreadPool(store);
         ArrayList<Future<Integer>> txTasks = new ArrayList<>(10000);
         for (int i = 0; i < 10000; i++) {
             final int txNumber = i;

--- a/tests/objectbox-java-test/src/test/java/io/objectbox/TransactionTest.java
+++ b/tests/objectbox-java-test/src/test/java/io/objectbox/TransactionTest.java
@@ -456,7 +456,7 @@ public class TransactionTest extends AbstractObjectBoxTest {
 
         //Iterate through all the txTasks and make sure all transactions succeeded.
         for (Future<Integer> txTask : txTasks) {
-            txTask.get(1, TimeUnit.MILLISECONDS);
+            txTask.get(1, TimeUnit.SECONDS);
         }
     }
 }


### PR DESCRIPTION
…ed in rapid succession (even when synchronized) on a bunch of thread pool threads. Currently, in ObjectBox 2.9.1, this fails.
